### PR TITLE
fix: fixed race condition on JWT token

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -6,6 +6,10 @@ class Middleware {
     if (req.headers.authorization) {
       token = req.headers.authorization.split(" ")[1];
     }
+
+    if (!token || token == "Bearer")
+      return res.json({ message: "Firebase ID string not set as JWT yet" });
+
     try {
       const decodeValue = await admin.auth().verifyIdToken(token);
       if (decodeValue) {


### PR DESCRIPTION
### Overview

Race condition on Firebase token caused error to pop up in console. Initially is undefined then is set to Firebase token, and when it is initially undefined, it causes the error.